### PR TITLE
Rollback version required for core-bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ atlassian-ide-plugin.xml
 composer.phar
 
 composer.lock
+
+VERSION.txt

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.1",
-        "claroline/core-bundle": "~5.0"
+        "claroline/core-bundle": "~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
We will need this later when all the rest will be compatible with the core in version 5.0.

Maybe you can make a tag, and after I will recommit this update.
